### PR TITLE
Message details option for reactions and replies

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -213,7 +213,7 @@ export const chat_handler = async (
     if (message.hasQuotedMsg) {
       const repliedMessage = await message.getQuotedMessage();
       const repliedTime = longNumToDate(repliedMessage.timestamp);
-      const repliedNameId = repliedMessage.author || message.from;
+      const repliedNameId = repliedMessage.author || repliedMessage.from;
       const repliedContact = await client.getContactById(repliedNameId);
       const repliedName = waContactToName(repliedContact, false);
       let repliedMsg = repliedMessage.body;

--- a/views/chats.html
+++ b/views/chats.html
@@ -43,7 +43,10 @@
 		<a href="#" id="showDetails" onclick="document.getElementById('details{{this.id}}').classList.toggle('hidden'); return false;">Details</a>
 		<div id="details{{this.id}}" class="hidden">
 	      		{{#if this.hasReaction}}
-	        	<small>This message has reactions</small><br />
+	        	<small>Reactions:</small><br />
+			{{#each this.reactionsDetails}}
+				<small>{{this}}</small><br />
+			{{/each}}
 	      		{{/if}}
 	      		{{#if this.hasQuotedMessage}}
 	        	<small>Replies to:</small><br />

--- a/views/chats.html
+++ b/views/chats.html
@@ -5,6 +5,11 @@
 <link href="/public/css/style.css" rel="stylesheet">
 <meta name="theme-color" content="#305">
 <meta name="viewport" content="width=device-width">
+<style>
+  .hidden {
+    display: none;
+  } 
+</style>
 </head>
 <body>
     <nav class="navbar navbar-default">
@@ -32,9 +37,21 @@
         {{/if}}
          ({{this.time}}): {{#each this.msg}} {{this}} <br />{{/each}}
          {{#if this.media}}
-            <a href="/media/{{this.id}}">Download Attachment</a>
+            <a href="/media/{{this.id}}">Download Attachment</a><br />
          {{/if}}
-         
+	<small> {{#if this.showDetails}}
+		<a href="#" id="showDetails" onclick="document.getElementById('details{{this.id}}').classList.toggle('hidden'); return false;">Details</a>
+		<div id="details{{this.id}}" class="hidden">
+	      		{{#if this.hasReaction}}
+	        	<small>This message has reactions</small><br />
+	      		{{/if}}
+	      		{{#if this.hasQuotedMessage}}
+	        	<small>Replies to:</small><br />
+			<small>{{this.repliedMessage}}</small><br />
+	      		{{/if}}
+   		</div>
+		{{/if}}
+	</small>
          <hr /></br />
     {{/each}}
     <form method="post" action="/chats/{{chat_id}}/reply" enctype="multipart/form-data">


### PR DESCRIPTION
As discussed in https://github.com/tomtau/superbasic-im/discussions/12 this functionality is a button under every message that has reactions or replies to another message. It has been tested with Opera Mini 4.4 and Opera Mini 7.1, working great in both.

When a message has no reactions and it is not a reply this "Details" option is not shown.