### PR TITLE
Group information page accessible from group chat page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   reply_handler,
   vcard_handler,
   read_all_handler,
+  chat_info_handler,
 } from './routes';
 
 export let server: Server;
@@ -202,6 +203,11 @@ export const init = async function (): Promise<Server> {
       method: 'GET',
       path: '/chats/{chat_id}',
       handler: chat_handler,
+    },
+    {
+      method: 'GET',
+      path: '/chats/{chat_id}/info',
+      handler: chat_info_handler,
     },
     {
       method: 'GET',

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -181,11 +181,9 @@ export const media_handler = async (
 export const chat_info_handler = async (
   request: Request<ReqRefDefaults>,
   h: ResponseToolkit<ReqRefDefaults>
-
 ) => {
   let chatName = '';
   let chatDescription: string[] = [];
-  const id = encodeURIComponent(request.params.chat_id);
   const chat = await client.getChatById(request.params.chat_id);
   const participantList: {
     id: string;
@@ -195,22 +193,29 @@ export const chat_info_handler = async (
   if (chat.isGroup) {
     const groupChat = chat as GroupChat;
     chatName = groupChat.name;
-    if (groupChat.description != null) {
-       chatDescription = groupChat.description.split('\n');
+    if (groupChat.description !== null && groupChat.description !== undefined) {
+      chatDescription = groupChat.description.split('\n');
     }
     for (let i = 0; i < groupChat.participants.length; i++) {
-      const chatParticipant = await client.getContactById(groupChat.participants[i].id._serialized);
+      const chatParticipant = await client.getContactById(
+        groupChat.participants[i].id._serialized
+      );
       const participantName = waContactToName(chatParticipant, false);
       participantList.push({
-	id: groupChat.participants[i].id._serialized,
+        id: groupChat.participants[i].id._serialized,
         contactName: participantName,
         isAdmin: groupChat.participants[i].isAdmin,
       });
     }
   } else {
-	return h.response('Chat is not a group').code(400);
+    return h.response('Chat is not a group').code(400);
   }
-  return h.view('chatinfo', {chatId: request.params.chat_id, chatName: emoji.unemojify(chatName), chatDescription: chatDescription.map(m => emoji.unemojify(m)), participants: participantList});
+  return h.view('chatinfo', {
+    chatId: request.params.chat_id,
+    chatName: emoji.unemojify(chatName),
+    chatDescription: chatDescription.map(m => emoji.unemojify(m)),
+    participants: participantList,
+  });
 };
 
 export const chat_handler = async (

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -185,6 +185,7 @@ export const chat_info_handler = async (
 ) => {
   let chatName = '';
   let chatDescription: string[] = [];
+  const id = encodeURIComponent(request.params.chat_id);
   const chat = await client.getChatById(request.params.chat_id);
   const participantList: {
     id: string;
@@ -194,7 +195,9 @@ export const chat_info_handler = async (
   if (chat.isGroup) {
     const groupChat = chat as GroupChat;
     chatName = groupChat.name;
-    chatDescription = groupChat.description.split('\n');
+    if (groupChat.description != null) {
+       chatDescription = groupChat.description.split('\n');
+    }
     for (let i = 0; i < groupChat.participants.length; i++) {
       const chatParticipant = await client.getContactById(groupChat.participants[i].id._serialized);
       const participantName = waContactToName(chatParticipant, false);
@@ -307,7 +310,7 @@ export const chat_handler = async (
   return h.view('chats', {
     messages: fmtMsg,
     chat_unreadMessages: unreadMessages,
-    chat_id: request.params.chat_id,
+    chat_id: encodeURIComponent(request.params.chat_id),
     groupChat: chat.isGroup,
   });
 };

--- a/views/chatinfo.html
+++ b/views/chatinfo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+<title>SuperBasic IM</title>
+<link href="/public/css/style.css" rel="stylesheet">
+<meta name="theme-color" content="#305">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+    <nav class="navbar navbar-default">
+        <div class="container-fluid">
+          <div class="navbar-header">
+            <a class="navbar-brand" href="/">SuperBasic IM</a>
+          </div>
+      
+          <div>
+            <ul class="nav navbar-nav navbar-right">
+		    <li><a href="/chats/{{chatId}}" class="btn btn-success" id="first-btn">Back to chat</a></li>
+            </ul>
+          </div><!-- /.navbar-collapse -->
+        </div>
+        </div>
+      </nav>
+<div class="chat-area">
+    <table>
+        <tbody>
+	    <strong>{{chatName}}</strong><br />
+	    <hr /><br />
+	    Description:<br />
+	    {{#each chatDescription}} {{this}} <br /> {{/each}}
+	    <hr /><br />
+	    Members:<br />
+	    <div class="participant-list">
+		<ul>
+	    	    {{#each participants}}
+		        <li>
+			    <a href="/chats/{{this.id}}/vcard">{{this.contactName}} </a>
+			    {{#if this.isAdmin}}
+			        <strong>Admin</strong>
+			    {{/if}}
+			</li>
+	    	    {{/each}}
+		<ul>
+	    </div>
+        </tbody>
+    </table>
+</div>
+<footer>
+  <ul class="nav nav-pills nav-stacked">
+    <li><strong><a href="/chats/{{chatId}}/info">Refresh</a></strong></li>
+  </ul>
+</footer>
+</body>
+</html>

--- a/views/chats.html
+++ b/views/chats.html
@@ -24,6 +24,9 @@
 	      {{#if chat_unreadMessages}}
 	      <li><a href="/chats/{{chat_id}}/seen" class="btn btn-success" id="first-btn">Mark all messages as read</a></li>
 	      {{/if}}
+	      {{#if groupChat}}
+              <li><a href="/chats/{{chat_id}}/info" class="btn btn-success" id="second-btn">Group information</a></li>
+              {{/if}}
             </ul>
           </div><!-- /.navbar-collapse -->
         </div>


### PR DESCRIPTION
In group chats there is a new option called "Group information" to move to another page where you can see the group description and members of the group.

The page looks like this:
<img src="https://github.com/user-attachments/assets/5dd2025a-7f3c-4ddd-915d-5b3fe47bef9e" alt="Alt Text" width="230" height="350">