### PR TITLE
Load unread messages until 50, after that shows an option to load all unread messages.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,12 @@ export const init = async function (): Promise<Server> {
     {
       method: 'GET',
       path: '/chats/{chat_id}',
-      handler: chat_handler,
+      handler: (request, h) => chat_handler(request, h, false),
+    },
+    {
+      method: 'GET',
+      path: '/chats/{chat_id}/allunreadmessages',
+      handler: (request, h) => chat_handler(request, h, true),
     },
     {
       method: 'GET',

--- a/views/chats.html
+++ b/views/chats.html
@@ -20,13 +20,16 @@
       
           <div>
             <ul class="nav navbar-nav navbar-right">
-	      {{#if chat_unreadMessages}}
-	      <li><a href="/chats/{{chat_id}}/seen" class="btn btn-success" id="first-btn">Mark all messages as read</a></li>
-	      {{/if}}
-	      {{#if groupChat}}
+	            {{#if chat_unreadMessages}}
+	            <li><a href="/chats/{{chat_id}}/seen" class="btn btn-success" id="first-btn">Mark all messages as read</a></li>
+	            {{/if}}
+	            {{#if groupChat}}
               <li><a href="/chats/{{chat_id}}/info" class="btn btn-success" id="second-btn">Group information</a></li>
-	      {{else}}
-	      <li><a href="/chats/{{chat_id}}/vcard" class="btn btn-success" id="second-btn">Download Vcard</a></li>
+	            {{else}}
+	            <li><a href="/chats/{{chat_id}}/vcard" class="btn btn-success" id="second-btn">Download Vcard</a></li>
+              {{/if}}
+              {{#if chat_tooManyUnreadMessages}}
+              <li><a href="/chats/{{chat_id}}/allunreadmessages" class="btn btn-success" id="first-btn">Show {{amountUnreadMessages}} unread messages</a></li>
               {{/if}}
             </ul>
           </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
Fixes https://github.com/tomtau/superbasic-im/issues/21
Now the behaviour changes when there are more than 10 unread messages in the chat.
The program loads until it reaches to 50 and after that there is a new option to load all unread messages.