### PR TITLE
Text area doesn't have "Reply..." placeholder anymore

### DIFF
--- a/views/chats.html
+++ b/views/chats.html
@@ -66,7 +66,7 @@
     {{/each}}
     <form method="post" action="/chats/{{chat_id}}/reply" enctype="multipart/form-data">
       <input type="hidden" name="crumb" value="{{crumb}}"/>
-      <textarea class="form-control" id="message" name="message" rows="3" placeholder="Reply..."></textarea>
+      <textarea class="form-control" id="message" name="message" rows="3"></textarea>
       <div class="form-group">
           <label for="file">Attachment</label>
           <input type="file" class="form-control" id="file" name="file" />


### PR DESCRIPTION
Fixes https://github.com/tomtau/superbasic-im/issues/26
This fix has been implemented only on chat.html view but not in new.html. I think this placeholder in new.html is needed for undersanding what the text area does.